### PR TITLE
feat: rework to use logging 1.5.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,11 @@ go 1.19
 
 require (
 	cloud.google.com/go/compute v1.8.0
-	cloud.google.com/go/logging v1.5.0-jsonlog-preview
+	cloud.google.com/go/logging v1.5.0
 	github.com/gorilla/mux v1.8.0
 	golang.org/x/oauth2 v0.0.0-20220808172628-8227340efae7
 	google.golang.org/api v0.92.0
+	google.golang.org/grpc v1.48.0
 )
 
 require (
@@ -24,6 +25,5 @@ require (
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20220804142021-4e6b2dfa6612 // indirect
-	google.golang.org/grpc v1.48.0 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -47,8 +47,8 @@ cloud.google.com/go/compute v1.8.0/go.mod h1:boQ44qJsMqZjKzzsEkoJWQGj4h8ygmyk17U
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 cloud.google.com/go/datastore v1.1.0/go.mod h1:umbIZjpQpHh4hmRpGhH4tLFup+FVzqBi1b3c64qFpCk=
 cloud.google.com/go/iam v0.3.0/go.mod h1:XzJPvDayI+9zsASAFO68Hk07u3z+f+JrT2xXNdp4bnY=
-cloud.google.com/go/logging v1.5.0-jsonlog-preview h1:ytQ2SSy+rh+fGUDdRo8zHeHTi+fhcZMyUddSgYhbugc=
-cloud.google.com/go/logging v1.5.0-jsonlog-preview/go.mod h1:A26OFzlArW55bhS1qMGlgsctgae2DbXoFE7JAtzGVco=
+cloud.google.com/go/logging v1.5.0 h1:DcR52smaYLgeK9KPzJlBJyyBYqW/EGKiuRRl8boL1s4=
+cloud.google.com/go/logging v1.5.0/go.mod h1:c/57U/aLdzSFuBtvbtFduG1Ii54uSm95HOBnp58P7/U=
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
 cloud.google.com/go/pubsub v1.1.0/go.mod h1:EwwdRX2sKPjnvnqCa270oGRyludottCI76h+R3AArQw=
 cloud.google.com/go/pubsub v1.2.0/go.mod h1:jhfEVHT8odbXTkndysNHCcx0awwzvfOlguIAii9o8iA=
@@ -560,7 +560,6 @@ google.golang.org/genproto v0.0.0-20210402141018-6c239bbf2bb1/go.mod h1:9lPAdzaE
 google.golang.org/genproto v0.0.0-20210513213006-bf773b8c8384/go.mod h1:P3QM42oQyzQSnHPnZ/vqoCdDmzH28fzWByN9asMeM8A=
 google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c/go.mod h1:UODoCrxHCcBojKKwX1terBiRUaqAsFqJiF615XL43r0=
 google.golang.org/genproto v0.0.0-20210604141403-392c879c8b08/go.mod h1:UODoCrxHCcBojKKwX1terBiRUaqAsFqJiF615XL43r0=
-google.golang.org/genproto v0.0.0-20210607140030-00d4fb20b1ae/go.mod h1:UODoCrxHCcBojKKwX1terBiRUaqAsFqJiF615XL43r0=
 google.golang.org/genproto v0.0.0-20210608205507-b6d2f5bf0d7d/go.mod h1:UODoCrxHCcBojKKwX1terBiRUaqAsFqJiF615XL43r0=
 google.golang.org/genproto v0.0.0-20210624195500-8bfb893ecb84/go.mod h1:SzzZ/N+nwJDaO1kznhnlzqS8ocJICar6hYhVyhi++24=
 google.golang.org/genproto v0.0.0-20210713002101-d411969a0d9a/go.mod h1:AxrInvYm1dci+enl5hChSFPOmmUF1+uAa/UsgNRWd7k=

--- a/handler.go
+++ b/handler.go
@@ -17,11 +17,18 @@ package main
 import (
 	"fmt"
 	"net/http"
+
+	"cloud.google.com/go/logging"
 )
 
 func (a *App) Handler(w http.ResponseWriter, r *http.Request) {
-	a.log.WithRequest(r).
-		WithLabels(map[string]string{"arbitraryField": "custom entry"}).
-		Infof("Structured logging example.")
+	a.log.Log(logging.Entry{
+		Severity: logging.Info,
+		HTTPRequest: &logging.HTTPRequest{
+			Request: r,
+		},
+		Labels:  map[string]string{"arbitraryField": "custom entry"},
+		Payload: "Structured logging example.",
+	})
 	fmt.Fprintf(w, "Hello World!\n")
 }


### PR DESCRIPTION
The jsonlog package previously used is no longer exists. It has been
incorperated directly into the logging package. This is the equivalent
code to log out structured logging.