### PR TITLE
fix: stop pinning a specific go version, rely on go.mod

### DIFF
--- a/advance.cloudbuild.yaml
+++ b/advance.cloudbuild.yaml
@@ -12,15 +12,15 @@
 steps:
 
 - id: 'Download dependencies'
-  name: golang:1.16.15
+  name: golang
   args: ['go', 'mod', 'download']
 
 - id: 'Install linting tools'
-  name: golang:1.16.15
+  name: golang
   args: ['go', 'install', 'golang.org/x/tools/cmd/goimports@latest']
 
 - id: 'Lint'
-  name: golang:1.16.15
+  name: golang
   entrypoint: /bin/bash
   args:
     - '-c'
@@ -28,7 +28,7 @@ steps:
       goimports -l . 2>&1 | tee /dev/stderr | (! read)
 
 - id: 'Run Unit Tests'
-  name: golang:1.16.15
+  name: golang
   args: ['go', 'test', '-v', './...']
 
 # Setup resources for system tests
@@ -75,7 +75,7 @@ steps:
     - 'PROJECT_ID=${PROJECT_ID}'
   
 - id: 'Run System Tests'
-  name: golang:1.16.15
+  name: golang
   entrypoint: /bin/bash
   args:
     - '-c'

--- a/system_test.go
+++ b/system_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build system
 // +build system
 
 package main


### PR DESCRIPTION
also updates build directives in system_test.go, to account for moving
from go116 to go119

It is pretty safe to do this because golang is very careful about backward
compatability, and go.mod controls which version of the language is used to
compile.
