### PR TITLE
chore: renovate force.constraint => constraint

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,9 +20,7 @@
       "enabled": false
     }
   ],
-  "force": {
-    "constraints": {
-      "go": "1.16"
-    }
+  "constraints": {
+    "go": "1.19"
   }
 }


### PR DESCRIPTION
This is a prerequisite to fix https://github.com/GoogleCloudPlatform/cloud-run-microservice-template-go/pull/314#issuecomment-1343275792 to see if the renovate constraint config might work better in the future to tolerate out-of-band update to go version.

Minimally, it updates the go version to 1.19 to match the current reality of the project since #311 