### PR TITLE
chore: use latest buildpack

### DIFF
--- a/advance.cloudbuild.yaml
+++ b/advance.cloudbuild.yaml
@@ -37,7 +37,7 @@ steps:
   entrypoint: pack
   args:
     - build
-    - '--builder=gcr.io/buildpacks/builder:v1'
+    - '--builder=gcr.io/buildpacks/builder:latest'
     - '$_GCR_HOSTNAME/$PROJECT_ID/$_REPOSITORY/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA'
     
 


### PR DESCRIPTION
Update buildpack version to use "latest" OS instead of pinning OS version. 
Goals: Keep OS up to date to reduce CVE, but removes best practices of pinning versions for consistent builds.