### PR TITLE
chore: revert base extends

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "config:recommended",
+    "config:base",
     "schedule:weekly"
   ],
   "semanticCommits": "disabled",


### PR DESCRIPTION
Since the automatic config update in https://github.com/GoogleCloudPlatform/cloud-run-microservice-template-go/pull/378, no renovate update has successfully updated the go.sum files. Last successful update in https://github.com/GoogleCloudPlatform/cloud-run-microservice-template-go/pull/369, before #378. 

This PR reverts the `config:recommended` (https://docs.renovatebot.com/presets-config/#configrecommended) to `config:base`. 

After submission, rebasing #392 should create a green PR. 